### PR TITLE
Update scapy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-scapy ; python_version < '3.0'
-scapy-python3 ; python_version >= '3.4'
+scapy>=2.4.0
 argparse


### PR DESCRIPTION
scapy-python3 is an unofficial fork that is getting very oudated (many bug fixes missing).
Migrates to original and up-to-date scapy, which now supports both python 2 and 3