### PR TITLE
Support for IPv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The following flow declaration would describe a flow going from a computer to a 
 
  	flow dns_request udp  mydesktop.corp.acme.com:11234 > 8.8.8.8:53;
 
-The following flow declaration would describle a flow using IPv6 addresses:
+The following flow declaration would describe a flow using IPv6 addresses:
 
  	flow default tcp [2600:1337:2800:1:248:1893:25c8:d1]:31337 > [2600:1337:2800::f1]:80 (tcp.initialize;);
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ You can declare a flow using the following syntax:
 
 	flow [flow name] [proto] [src]:[srcport] [directionality] [dst]:[dstport] ([flow options]);
 
+
+*src* and *dst* can be IPv4 addresses, IPv6 addresses, or resolvable domain names.  For IPv6, the address(es) must be enclosed in square brackets ('[' and ']').
+
 The following flow declaration would describe a flow going from a computer to google.com:
 
  	flow my_connection tcp mydesktop.corp.acme.com:44123 > google.com:80 (tcp.initialize;);
@@ -76,6 +79,10 @@ The following flow declaration would describe a flow going from a computer to go
 The following flow declaration would describe a flow going from a computer to a DNS server:
 
  	flow dns_request udp  mydesktop.corp.acme.com:11234 > 8.8.8.8:53;
+
+The following flow declaration show a flow over IPv6:
+
+ 	flow default tcp [2600:1337:2800:1:248:1893:25c8:d1]:31337 > [2600:1337:2800::f1]:80 (tcp.initialize;);
 
 For the interim, directionality should always be specified as to server: >
 
@@ -175,4 +182,4 @@ The *tcp.flags.rst* attribute tells Flowsynth to force the packet to be a RST pa
 
 +	David Wharton
 +	@2xyo
-
++	@bhaan

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The following flow declaration would describe a flow going from a computer to a 
 
  	flow dns_request udp  mydesktop.corp.acme.com:11234 > 8.8.8.8:53;
 
-The following flow declaration show a flow over IPv6:
+The following flow declaration would describle a flow using IPv6 addresses:
 
  	flow default tcp [2600:1337:2800:1:248:1893:25c8:d1]:31337 > [2600:1337:2800::f1]:80 (tcp.initialize;);
 

--- a/examples/ipv6-http-get.fs
+++ b/examples/ipv6-http-get.fs
@@ -1,0 +1,3 @@
+flow default tcp [2606:2800:220:1:248:1893:25c8:1946]:44123 > [2607:f8b0:4004:800::200e]:80 (tcp.initialize;);
+default > (content:"GET / HTTP/1.1\x0d\x0aHost:google.com\x0d\x0aUser-Agent: DogBot\x0d\x0a\x0d\x0a";);
+default < (content:"HTTP/1.1 200 OK\x0d\x0aContent-Length: 300\x0d\x0a\x0d\x0aWelcome to Google.com!\x0d\x0a\x0d\x0a";);


### PR DESCRIPTION
Implements issue #8

This is a simple changeset for adding IPv6 support while preserving backwards compatibility. A likely better approach for this would be to explicitly describe the layer 3 protocol in the synfile, similar to how the layer 4 protocol (tcp/udp) is described. But that would require more thought to avoid breaking current behavior.

This implementation was sufficient for my use case, but let me know if you would like to approach this in a different way.