### PR TITLE
Import print_function for Python 2. Fixes #23

### DIFF
--- a/src/flowsynth.py
+++ b/src/flowsynth.py
@@ -18,8 +18,7 @@
 
    author: Will Urbanski <will.urbanski@gmail.com>
 """
-
-
+from __future__ import print_function
 
 import argparse
 import logging
@@ -39,6 +38,8 @@ from scapy.all import Ether, IP, IPv6, TCP, UDP, RandMAC, hexdump, wrpcap
 
 #global variables
 APP_VERSION_STRING = "1.3.1"
+# Define the standard version indicator.
+__version__ = APP_VERSION_STRING
 LOGGING_LEVEL = logging.INFO
 ARGS = None
 


### PR DESCRIPTION
* Simply add required import from __future__ to make python 2 print statements actual functions.
* Also define the standard library `__version__` string.