### PR TITLE
Payload Endoding issue (multi-byte UTF8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The following event attributes are currently supported:
 +   tcp.flags.rst
 
 ##### Content Attribute #####
-The *content* attribute is used to specify the payload of a packet. Content attributes must be enclosed in double quotes. Special characters can be expressed in hex, like: *\x0d\x0a*. Anything prefaced with \x will be converted from hex to its ascii representation. These translation takes place during the render phase.
+The *content* attribute is used to specify the payload of a packet. Content attributes must be enclosed in double quotes. UTF-8 is supported and arbitrary bytes can be expressed with the "\xHH" notation where "HH" is the hexidecimal representation of the byte. For example, a carriage return (ASCII 0x0D) followed by a line feed (ASCII 0x0A) can be defined like this: *\x0D\x0A*.  This translation takes place during the render phase.
 
 Example:
 

--- a/examples/dns-request.fs
+++ b/examples/dns-request.fs
@@ -1,0 +1,31 @@
+flow dns_request udp 10.200.31.12:11234 > 8.8.8.8:53;
+
+dns_request > (
+    # transaction ID (should be random two bytes)
+    content:"\xBA\xBE";
+
+    # flags; set as appropriate (see RFC)
+    content:"\x01\x00";
+
+    # Number of questions
+    content:"\x00\x01";
+
+    # answer resource records
+    content:"\x00\x00";
+
+    # authority resource records
+    content:"\x00\x00";
+
+    # additional resource records
+    content:"\x00\x00";
+
+    # queries
+    # name (len, value, len, value, ... null)
+    content:"\x05linux\x16georgepburdell-desktop\x04corp\x04acme\x03com\x00";
+
+    # type (\x0001 is A)
+    content:"\x00\x01";
+
+    # class (0x0001 is IN/Internet)
+    content:"\x00\x01";
+);

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="flowsynth",
-    version="1.3.2",
+    version="1.4.0",
     author="Will Urbanski",
     maintainer="David Wharton",
     maintainer_email="counterthreatunit@users.noreply.github.com",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="flowsynth",
-    version="1.3.1",
+    version="1.3.2",
     author="Will Urbanski",
     maintainer="David Wharton",
     maintainer_email="counterthreatunit@users.noreply.github.com",

--- a/src/flowsynth.py
+++ b/src/flowsynth.py
@@ -19,7 +19,7 @@
    author: Will Urbanski <will.urbanski@gmail.com>
 """
 
-
+#from __future__ import print_function
 
 import argparse
 import logging
@@ -40,6 +40,7 @@ from scapy.all import Ether, IP, IPv6, TCP, UDP, RandMAC, hexdump, wrpcap, Raw
 
 #global variables
 APP_VERSION_STRING = "1.4.0"
+__version__ = APP_VERSION_STRING
 LOGGING_LEVEL = logging.INFO
 ARGS = None
 

--- a/src/flowsynth.py
+++ b/src/flowsynth.py
@@ -479,6 +479,9 @@ class Flow:
             logging.debug("Content: %s (length %d)" % (content_text, len(content_text)))
             start = 0
             previous_end = 0
+            # Flowsynth supports encoding arbitrary bytes with the "\xHH" notation where "HH" is
+            # the hexidecimal representation of the byte. That is what is handled here, while
+            # maintaining the rest of the content data as UTF-8.
             for hex_replacement in re.finditer(r"\\x[a-fA-F0-9]{2}", content_text):
                 # try/catch blocks to deal with different data representation from shlex (depends on Python version)
                 start = hex_replacement.start(0)


### PR DESCRIPTION
The payload is stored in "payload" variable which type str [_sic_].  Therefore,
you can end up with situations where bytes (e.g. entered with hex encoding)
get interpreted as multi-byte UTF8 (and expanded) when passed to scapy which
is not the desired behavior.  Fixed with bytearray and the
scapy Raw() function.

Special thanks to Tom B. for identifying the bug and solution.

Also fixed variable scoping bug that prevented logging levels being set
properly based on command line options.